### PR TITLE
Allow using unmodified content-resources for custom DBs

### DIFF
--- a/content-resources/README.md
+++ b/content-resources/README.md
@@ -7,6 +7,10 @@ The database properties can be modified in oskari-server/content-resources/src/m
 Also these database-settings can be overridden by using -Doskari.env=myenv parameter on maven call.
 This reads db.properties as base, reads an additional properties file db-myenv.properties and overrides any keys found in base properties with the env-specific properties.
 
+Finally it is possible to provide properties using any .properties file by specifying the path to the file
+as the first command line argument. This is useful if you wish to run the DB populator as a standalone unmodified
+.jar file.
+
 ## Populating database content
 
 After the database connection parameters have been configured the database can be populated with maven running (in oskari-server/content-resources):
@@ -72,3 +76,15 @@ Layers can be added without running whole setup-files. Add a sample layer with t
 
 The layer JSON is parsed and added as layer to the db as it would have been if it had been referenced in a setup/view-file.
 Referenced files have base dir src/main/resources/json/layers.
+
+# Resource overlay files
+
+You can place new or modified setup files in an external directory tree that follows the same structure
+as the files under the resource directory. You must provide the path to this directory using the parameter
+-Doskari.resourceOverlayDir=/path/to/your/overlay/directory. This makes it possible to use the DB populator
+as a standalone tool without modifying the resources contained in it and store your application specific
+configuration elsewhere:
+
+    mvn assembly:assembly
+    java "-Doskari.dropdb=true" "-Doskari.setup=yourapp" "-Doskari.resourceOverlayDir=c:/your/overlay" \
+    -jar target/content-resources-VERSION-jar-with-dependencies.jar c:/your/db/env.properties

--- a/content-resources/pom.xml
+++ b/content-resources/pom.xml
@@ -61,6 +61,20 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.5</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                        </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>fi.nls.oskari.db.DBHandler</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -82,6 +96,12 @@
             <artifactId>commons-dbcp2</artifactId>
             <version>${commons-dbcp2.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>9.3-1102-jdbc41</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Populating the Oskari database as documented in http://oskari.org/documentation/backend/database-populate would require maintaining a custom fork of content-resources project. Even if the changes would be small this is something I wanted to avoid. The changes in this commit allows us to maintain our application specific definitions in a separate Git repository and still take advantage of improvements made to oskari-server. An additional advantage of these changes is that we can now run all of the schema-modifying operations from a system that does not have Maven installed.

Please check if this approach seems sensible to you (changes to README.md have all the details). It should at least not break any existing workflows but of course if there already is a better way of achieving the same goal we could use that as well.