### PR TITLE
Fix missing primary key from oskari_permission

### DIFF
--- a/content-resources/src/main/resources/sql/PostgreSQL/create-base-tables.sql
+++ b/content-resources/src/main/resources/sql/PostgreSQL/create-base-tables.sql
@@ -152,7 +152,8 @@ CREATE TABLE oskari_permission
   oskari_resource_id bigint NOT NULL,
   external_type character varying(100),
   permission character varying(100),
-  external_id character varying(1000)
+  external_id character varying(1000),
+  CONSTRAINT oskari_permission_pkey PRIMARY KEY (id)
 );
 
 CREATE TABLE portti_backendstatus


### PR DESCRIPTION
Did not see a reason why "id" did not have primary key constraint. We use pgAdmin at Luke and it requires that either primary key or OIDs must be present in order to allow editing the data through the graphical UI.