### PR TITLE
Save new passwords using BCrypt hash instead of MD5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,11 @@
                 <artifactId>spring-security-config</artifactId>
                 <version>${spring-security.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-crypto</artifactId>
+                <version>${spring-security.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>xerces</groupId>

--- a/service-users/pom.xml
+++ b/service-users/pom.xml
@@ -19,6 +19,10 @@
             <groupId>fi.nls.oskari.service</groupId>
             <artifactId>oskari-base</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
     </dependencies>
     <build>
     	<pluginManagement>


### PR DESCRIPTION
For login both hash formats are still supported. This change is the service layer change needed for the user registration functionality developed at Luke.